### PR TITLE
Add passkey/WebAuthN support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,7 @@ val hopliteVersion: String by project
 val xmlUtilVersion: String by project
 val koinVersion: String by project
 val koinAnnotationsVersion: String by project
+val webauthnVersion: String by project
 
 plugins {
     kotlin("jvm") version "2.3.21"
@@ -83,6 +84,7 @@ dependencies {
     implementation("ch.qos.logback:logback-classic:$logbackVersion")
     implementation("com.fasterxml.uuid:java-uuid-generator:5.2.0")
     implementation("at.favre.lib:bcrypt:0.10.2")
+    implementation("com.yubico:webauthn-server-core:$webauthnVersion")
 
     // Exposed + database drivers
     implementation("org.jetbrains.exposed:exposed-core:$exposedVersion")

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,3 +11,4 @@ hopliteVersion=2.9.0
 xmlUtilVersion=0.91.3
 koinVersion=4.2.1
 koinAnnotationsVersion=2.3.1
+webauthnVersion=2.9.0

--- a/src/main/kotlin/io/pcast/config/Configuration.kt
+++ b/src/main/kotlin/io/pcast/config/Configuration.kt
@@ -4,10 +4,19 @@ data class Configuration(
     val database: Database,
     val jwt: JwtConfig,
     val cors: CorsConfig = CorsConfig(),
+    val passkey: PasskeyConfig = PasskeyConfig(),
 )
 
 data class CorsConfig(
     val allowedOrigins: List<String> = emptyList(),
+)
+
+data class PasskeyConfig(
+    val rpId: String = "localhost",
+    val rpName: String = "pcast",
+    val allowedOrigins: List<String> = listOf("http://localhost:3000"),
+    val challengeTtlSeconds: Long = 300,
+    val timeoutMillis: Long = 60000,
 )
 
 data class JwtConfig(

--- a/src/main/kotlin/io/pcast/module/Modules.kt
+++ b/src/main/kotlin/io/pcast/module/Modules.kt
@@ -24,6 +24,7 @@ val configModule =
             buildConfigurationFromFiles().also { config ->
                 validateJwtSecret(config.jwt.secret)
                 validateDatabaseCredentials(config)
+                validatePasskeyConfig(config)
             }
         }
     }
@@ -88,5 +89,23 @@ private fun validateJwtSecret(secret: String) {
     require(secret.length >= 32) {
         val length = secret.length
         "JWT secret must be at least 32 characters long for security. Current length: $length"
+    }
+}
+
+private fun validatePasskeyConfig(config: Configuration) {
+    require(config.passkey.rpId.isNotBlank()) {
+        "passkey.rpId must not be blank."
+    }
+    require(config.passkey.rpName.isNotBlank()) {
+        "passkey.rpName must not be blank."
+    }
+    require(config.passkey.allowedOrigins.isNotEmpty()) {
+        "passkey.allowedOrigins must include at least one web client origin."
+    }
+    require(config.passkey.challengeTtlSeconds in 60..600) {
+        "passkey.challengeTtlSeconds must be between 60 and 600 seconds."
+    }
+    require(config.passkey.timeoutMillis in 1000..300000) {
+        "passkey.timeoutMillis must be between 1000 and 300000 milliseconds."
     }
 }

--- a/src/main/kotlin/io/pcast/module/auth/AuthService.kt
+++ b/src/main/kotlin/io/pcast/module/auth/AuthService.kt
@@ -43,7 +43,7 @@ class AuthService(
                 .findByEmail(email)
                 ?.takeIf { verifyPassword(password, it.passwordHash) }
 
-        return user?.let { generateTokenPair(it) }
+        return user?.let { issueTokenPair(it) }
     }
 
     fun refresh(refreshToken: String): TokenResponse? {
@@ -56,7 +56,7 @@ class AuthService(
 
         refreshTokenRepository.deleteByTokenHash(tokenHash)
 
-        return userRepository.findById(storedToken.userId)?.let { generateTokenPair(it) }
+        return userRepository.findById(storedToken.userId)?.let { issueTokenPair(it) }
     }
 
     fun logout(refreshToken: String): Boolean {
@@ -79,7 +79,7 @@ class AuthService(
 
     fun getUserByEmail(email: String): User? = userRepository.findByEmail(email)
 
-    private fun generateTokenPair(user: User): TokenResponse {
+    fun issueTokenPair(user: User): TokenResponse {
         val accessToken = generateAccessToken(user)
         val refreshToken = generateRefreshToken(user)
 

--- a/src/main/kotlin/io/pcast/module/auth/api/AuthRouter.kt
+++ b/src/main/kotlin/io/pcast/module/auth/api/AuthRouter.kt
@@ -1,27 +1,41 @@
 package io.pcast.module.auth.api
 
+import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
+import io.ktor.server.auth.authenticate
 import io.ktor.server.plugins.ratelimit.rateLimit
 import io.ktor.server.request.receive
+import io.ktor.server.request.receiveText
 import io.ktor.server.response.header
 import io.ktor.server.response.respond
+import io.ktor.server.response.respondText
 import io.ktor.server.routing.Route
+import io.ktor.server.routing.delete
+import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.pcast.error.AbortError
 import io.pcast.error.HttpError
+import io.pcast.extensions.userId
 import io.pcast.module.auth.AuthService
+import io.pcast.module.auth.passkey.PasskeyService
+import io.pcast.module.auth.passkey.request.PasskeyAuthenticationOptionsRequest
+import io.pcast.module.auth.passkey.response.PasskeyCredentialResponse
 import io.pcast.module.auth.request.LoginRequest
 import io.pcast.module.auth.request.RefreshRequest
+import io.pcast.plugins.JWT_AUTH_NAME
 import io.pcast.plugins.RATE_LIMIT_LOGIN
+import io.pcast.plugins.RATE_LIMIT_PASSKEY
 import io.pcast.plugins.RATE_LIMIT_REFRESH
 import org.koin.ktor.ext.inject
 import org.slf4j.LoggerFactory
+import java.util.UUID
 
 private val log = LoggerFactory.getLogger("AuthRouter")
 
 fun Route.registerAuthRoutes() {
     val authService by inject<AuthService>()
+    val passkeyService by inject<PasskeyService>()
 
     rateLimit(RATE_LIMIT_LOGIN) {
         post("/auth/login") {
@@ -62,5 +76,56 @@ fun Route.registerAuthRoutes() {
 
         call.response.header(HttpHeaders.CacheControl, "no-store")
         call.respond(HttpStatusCode.NoContent)
+    }
+
+    authenticate(JWT_AUTH_NAME) {
+        post("/auth/passkeys/registration/options") {
+            val optionsJson = passkeyService.startRegistration(call.userId())
+
+            call.response.header(HttpHeaders.CacheControl, "no-store")
+            call.respondText(optionsJson, ContentType.Application.Json, HttpStatusCode.OK)
+        }
+
+        post("/auth/passkeys/registration/finish") {
+            val credential = passkeyService.finishRegistration(call.userId(), call.receiveText())
+
+            call.response.header(HttpHeaders.CacheControl, "no-store")
+            call.respond(HttpStatusCode.Created, PasskeyCredentialResponse(credential))
+        }
+
+        get("/auth/passkeys") {
+            val credentials = passkeyService.listCredentials(call.userId()).map(::PasskeyCredentialResponse)
+
+            call.response.header(HttpHeaders.CacheControl, "no-store")
+            call.respond(HttpStatusCode.OK, credentials)
+        }
+
+        delete("/auth/passkeys/{id}") {
+            val credentialId =
+                call.parameters["id"]
+                    ?.let { runCatching { UUID.fromString(it) }.getOrNull() }
+                    ?: throw AbortError(HttpError.BadRequest, "Passkey credential ID must be provided")
+
+            passkeyService.deleteCredential(call.userId(), credentialId)
+            call.response.header(HttpHeaders.CacheControl, "no-store")
+            call.respond(HttpStatusCode.NoContent)
+        }
+    }
+
+    rateLimit(RATE_LIMIT_PASSKEY) {
+        post("/auth/passkeys/authentication/options") {
+            val request = call.receive<PasskeyAuthenticationOptionsRequest>()
+            val optionsJson = passkeyService.startAuthentication(request.email)
+
+            call.response.header(HttpHeaders.CacheControl, "no-store")
+            call.respondText(optionsJson, ContentType.Application.Json, HttpStatusCode.OK)
+        }
+
+        post("/auth/passkeys/authentication/finish") {
+            val tokenResponse = passkeyService.finishAuthentication(call.receiveText())
+
+            call.response.header(HttpHeaders.CacheControl, "no-store")
+            call.respond(HttpStatusCode.OK, tokenResponse)
+        }
     }
 }

--- a/src/main/kotlin/io/pcast/module/auth/model/PasskeyChallenge.kt
+++ b/src/main/kotlin/io/pcast/module/auth/model/PasskeyChallenge.kt
@@ -1,0 +1,20 @@
+package io.pcast.module.auth.model
+
+import java.time.LocalDateTime
+import java.util.UUID
+
+enum class PasskeyChallengeType {
+    Registration,
+    Authentication,
+}
+
+data class PasskeyChallenge(
+    val id: UUID,
+    val userId: UUID?,
+    val type: PasskeyChallengeType,
+    val challenge: String,
+    val requestJson: String,
+    val expiresAt: LocalDateTime,
+    val consumedAt: LocalDateTime?,
+    val createdAt: LocalDateTime,
+)

--- a/src/main/kotlin/io/pcast/module/auth/model/PasskeyChallengeRepository.kt
+++ b/src/main/kotlin/io/pcast/module/auth/model/PasskeyChallengeRepository.kt
@@ -5,13 +5,17 @@ import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.dao.id.java.UUIDTable
 import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.greater
+import org.jetbrains.exposed.v1.core.isNotNull
 import org.jetbrains.exposed.v1.core.isNull
+import org.jetbrains.exposed.v1.core.lessEq
+import org.jetbrains.exposed.v1.core.or
 import org.jetbrains.exposed.v1.javatime.datetime
 import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.deleteWhere
 import org.jetbrains.exposed.v1.jdbc.insert
-import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
-import org.jetbrains.exposed.v1.jdbc.update
+import org.jetbrains.exposed.v1.jdbc.updateReturning
 import org.koin.core.annotation.Single
 import java.time.LocalDateTime
 import java.util.UUID
@@ -52,6 +56,8 @@ class PasskeyChallengeRepository(
                 createdAt = LocalDateTime.now(),
             )
 
+        purgeStale(LocalDateTime.now())
+
         transaction(db) {
             PasskeyChallengesTable.insert {
                 it[id] = pending.id
@@ -73,23 +79,28 @@ class PasskeyChallengeRepository(
         type: PasskeyChallengeType,
     ): PasskeyChallenge? =
         transaction(db) {
-            val pending =
-                PasskeyChallengesTable
-                    .selectAll()
-                    .where {
+            val now = LocalDateTime.now()
+
+            PasskeyChallengesTable
+                .updateReturning(
+                    returning = PasskeyChallengesTable.columns,
+                    where = {
                         (PasskeyChallengesTable.challenge eq challenge) and
                             (PasskeyChallengesTable.type eq type.name) and
-                            PasskeyChallengesTable.consumedAt.isNull()
-                    }.map(::mapRow)
-                    .singleOrNull()
-                    ?.takeIf { it.expiresAt.isAfter(LocalDateTime.now()) }
-                    ?: return@transaction null
+                            PasskeyChallengesTable.consumedAt.isNull() and
+                            (PasskeyChallengesTable.expiresAt greater now)
+                    },
+                ) {
+                    it[consumedAt] = now
+                }.map(::mapRow)
+                .singleOrNull()
+        }
 
-            PasskeyChallengesTable.update({ PasskeyChallengesTable.id eq pending.id }) {
-                it[consumedAt] = LocalDateTime.now()
+    fun purgeStale(now: LocalDateTime): Int =
+        transaction(db) {
+            PasskeyChallengesTable.deleteWhere {
+                (expiresAt lessEq now) or consumedAt.isNotNull()
             }
-
-            pending
         }
 
     private fun mapRow(row: ResultRow) =

--- a/src/main/kotlin/io/pcast/module/auth/model/PasskeyChallengeRepository.kt
+++ b/src/main/kotlin/io/pcast/module/auth/model/PasskeyChallengeRepository.kt
@@ -1,0 +1,106 @@
+package io.pcast.module.auth.model
+
+import io.pcast.helpers.generateUuidV7
+import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.dao.id.java.UUIDTable
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.isNull
+import org.jetbrains.exposed.v1.javatime.datetime
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.update
+import org.koin.core.annotation.Single
+import java.time.LocalDateTime
+import java.util.UUID
+
+private const val CHALLENGE_TYPE_MAX_LENGTH = 32
+private const val CHALLENGE_MAX_LENGTH = 512
+
+object PasskeyChallengesTable : UUIDTable("passkey_challenges") {
+    val userId = reference("user_id", UsersTable).nullable()
+    val type = varchar("type", CHALLENGE_TYPE_MAX_LENGTH)
+    val challenge = varchar("challenge", CHALLENGE_MAX_LENGTH).uniqueIndex()
+    val requestJson = text("request_json")
+    val expiresAt = datetime("expires_at")
+    val consumedAt = datetime("consumed_at").nullable()
+    val createdAt = datetime("created_at")
+}
+
+@Single
+class PasskeyChallengeRepository(
+    private val db: Database,
+) {
+    fun create(
+        userId: UUID?,
+        type: PasskeyChallengeType,
+        challenge: String,
+        requestJson: String,
+        expiresAt: LocalDateTime,
+    ): PasskeyChallenge {
+        val pending =
+            PasskeyChallenge(
+                id = generateUuidV7(),
+                userId = userId,
+                type = type,
+                challenge = challenge,
+                requestJson = requestJson,
+                expiresAt = expiresAt,
+                consumedAt = null,
+                createdAt = LocalDateTime.now(),
+            )
+
+        transaction(db) {
+            PasskeyChallengesTable.insert {
+                it[id] = pending.id
+                it[PasskeyChallengesTable.userId] = pending.userId
+                it[PasskeyChallengesTable.type] = pending.type.name
+                it[PasskeyChallengesTable.challenge] = pending.challenge
+                it[PasskeyChallengesTable.requestJson] = pending.requestJson
+                it[PasskeyChallengesTable.expiresAt] = pending.expiresAt
+                it[consumedAt] = pending.consumedAt
+                it[createdAt] = pending.createdAt
+            }
+        }
+
+        return pending
+    }
+
+    fun consume(
+        challenge: String,
+        type: PasskeyChallengeType,
+    ): PasskeyChallenge? =
+        transaction(db) {
+            val pending =
+                PasskeyChallengesTable
+                    .selectAll()
+                    .where {
+                        (PasskeyChallengesTable.challenge eq challenge) and
+                            (PasskeyChallengesTable.type eq type.name) and
+                            PasskeyChallengesTable.consumedAt.isNull()
+                    }.map(::mapRow)
+                    .singleOrNull()
+                    ?.takeIf { it.expiresAt.isAfter(LocalDateTime.now()) }
+                    ?: return@transaction null
+
+            PasskeyChallengesTable.update({ PasskeyChallengesTable.id eq pending.id }) {
+                it[consumedAt] = LocalDateTime.now()
+            }
+
+            pending
+        }
+
+    private fun mapRow(row: ResultRow) =
+        PasskeyChallenge(
+            id = row[PasskeyChallengesTable.id].value,
+            userId = row[PasskeyChallengesTable.userId]?.value,
+            type = PasskeyChallengeType.valueOf(row[PasskeyChallengesTable.type]),
+            challenge = row[PasskeyChallengesTable.challenge],
+            requestJson = row[PasskeyChallengesTable.requestJson],
+            expiresAt = row[PasskeyChallengesTable.expiresAt],
+            consumedAt = row[PasskeyChallengesTable.consumedAt],
+            createdAt = row[PasskeyChallengesTable.createdAt],
+        )
+}

--- a/src/main/kotlin/io/pcast/module/auth/model/PasskeyCredential.kt
+++ b/src/main/kotlin/io/pcast/module/auth/model/PasskeyCredential.kt
@@ -1,0 +1,18 @@
+package io.pcast.module.auth.model
+
+import java.time.LocalDateTime
+import java.util.UUID
+
+data class PasskeyCredential(
+    val id: UUID,
+    val userId: UUID,
+    val credentialId: String,
+    val publicKeyCose: String,
+    val signatureCount: Long,
+    val transports: String?,
+    val nickname: String?,
+    val backupEligible: Boolean?,
+    val backedUp: Boolean?,
+    val createdAt: LocalDateTime,
+    val lastUsedAt: LocalDateTime?,
+)

--- a/src/main/kotlin/io/pcast/module/auth/model/PasskeyCredentialRepository.kt
+++ b/src/main/kotlin/io/pcast/module/auth/model/PasskeyCredentialRepository.kt
@@ -1,0 +1,191 @@
+package io.pcast.module.auth.model
+
+import com.yubico.webauthn.RegisteredCredential
+import com.yubico.webauthn.data.ByteArray
+import com.yubico.webauthn.data.PublicKeyCredentialDescriptor
+import io.pcast.helpers.generateUuidV7
+import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.dao.id.java.UUIDTable
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.javatime.datetime
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.deleteWhere
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.update
+import org.koin.core.annotation.Single
+import java.time.LocalDateTime
+import java.util.UUID
+
+private const val CREDENTIAL_ID_MAX_LENGTH = 1024
+private const val TRANSPORTS_MAX_LENGTH = 255
+private const val NICKNAME_MAX_LENGTH = 255
+
+object PasskeyCredentialsTable : UUIDTable("passkey_credentials") {
+    val userId = reference("user_id", UsersTable)
+    val credentialId = varchar("credential_id", CREDENTIAL_ID_MAX_LENGTH).uniqueIndex()
+    val publicKeyCose = text("public_key_cose")
+    val signatureCount = long("signature_count").default(0)
+    val transports = varchar("transports", TRANSPORTS_MAX_LENGTH).nullable()
+    val nickname = varchar("nickname", NICKNAME_MAX_LENGTH).nullable()
+    val backupEligible = bool("backup_eligible").nullable()
+    val backedUp = bool("backed_up").nullable()
+    val createdAt = datetime("created_at")
+    val lastUsedAt = datetime("last_used_at").nullable()
+}
+
+@Single
+class PasskeyCredentialRepository(
+    private val db: Database,
+) {
+    fun create(
+        userId: UUID,
+        credentialId: String,
+        publicKeyCose: String,
+        signatureCount: Long,
+        transports: String?,
+        nickname: String?,
+        backupEligible: Boolean?,
+        backedUp: Boolean?,
+    ): PasskeyCredential {
+        val credential =
+            PasskeyCredential(
+                id = generateUuidV7(),
+                userId = userId,
+                credentialId = credentialId,
+                publicKeyCose = publicKeyCose,
+                signatureCount = signatureCount,
+                transports = transports,
+                nickname = nickname,
+                backupEligible = backupEligible,
+                backedUp = backedUp,
+                createdAt = LocalDateTime.now(),
+                lastUsedAt = null,
+            )
+
+        transaction(db) {
+            PasskeyCredentialsTable.insert {
+                it[id] = credential.id
+                it[PasskeyCredentialsTable.userId] = credential.userId
+                it[PasskeyCredentialsTable.credentialId] = credential.credentialId
+                it[PasskeyCredentialsTable.publicKeyCose] = credential.publicKeyCose
+                it[PasskeyCredentialsTable.signatureCount] = credential.signatureCount
+                it[PasskeyCredentialsTable.transports] = credential.transports
+                it[PasskeyCredentialsTable.nickname] = credential.nickname
+                it[PasskeyCredentialsTable.backupEligible] = credential.backupEligible
+                it[PasskeyCredentialsTable.backedUp] = credential.backedUp
+                it[createdAt] = credential.createdAt
+                it[lastUsedAt] = credential.lastUsedAt
+            }
+        }
+
+        return credential
+    }
+
+    fun listByUser(userId: UUID): List<PasskeyCredential> =
+        transaction(db) {
+            PasskeyCredentialsTable
+                .selectAll()
+                .where { PasskeyCredentialsTable.userId eq userId }
+                .map(::mapRow)
+        }
+
+    fun findByCredentialId(credentialId: String): PasskeyCredential? =
+        transaction(db) {
+            PasskeyCredentialsTable
+                .selectAll()
+                .where { PasskeyCredentialsTable.credentialId eq credentialId }
+                .map(::mapRow)
+                .singleOrNull()
+        }
+
+    fun findRegisteredByCredentialId(credentialId: ByteArray): Set<RegisteredCredential> =
+        findByCredentialId(credentialId.base64Url)
+            ?.let { setOf(it.toRegisteredCredential()) }
+            ?: emptySet()
+
+    fun findRegisteredByCredentialIdAndUserHandle(
+        credentialId: ByteArray,
+        userHandle: ByteArray,
+    ): RegisteredCredential? =
+        transaction(db) {
+            PasskeyCredentialsTable
+                .innerJoin(UsersTable)
+                .selectAll()
+                .where {
+                    (PasskeyCredentialsTable.credentialId eq credentialId.base64Url) and
+                        (UsersTable.passkeyUserHandle eq userHandle.base64Url)
+                }.map(::mapRow)
+                .singleOrNull()
+                ?.toRegisteredCredential(userHandle)
+        }
+
+    fun findDescriptorsByUser(userId: UUID): Set<PublicKeyCredentialDescriptor> =
+        listByUser(userId)
+            .map { credential ->
+                PublicKeyCredentialDescriptor
+                    .builder()
+                    .id(ByteArray.fromBase64Url(credential.credentialId))
+                    .build()
+            }.toSet()
+
+    fun updateAfterAuthentication(
+        credentialId: String,
+        signatureCount: Long,
+        backupEligible: Boolean?,
+        backedUp: Boolean?,
+    ): Boolean =
+        transaction(db) {
+            PasskeyCredentialsTable.update({ PasskeyCredentialsTable.credentialId eq credentialId }) {
+                it[PasskeyCredentialsTable.signatureCount] = signatureCount
+                it[PasskeyCredentialsTable.backupEligible] = backupEligible
+                it[PasskeyCredentialsTable.backedUp] = backedUp
+                it[lastUsedAt] = LocalDateTime.now()
+            } > 0
+        }
+
+    fun deleteForUser(
+        userId: UUID,
+        credentialId: UUID,
+    ): Boolean =
+        transaction(db) {
+            PasskeyCredentialsTable.deleteWhere {
+                (PasskeyCredentialsTable.id eq credentialId) and (PasskeyCredentialsTable.userId eq userId)
+            } > 0
+        }
+
+    private fun PasskeyCredential.toRegisteredCredential(userHandle: ByteArray? = null): RegisteredCredential =
+        RegisteredCredential
+            .builder()
+            .credentialId(ByteArray.fromBase64Url(credentialId))
+            .userHandle(userHandle ?: userHandleForUser(userId))
+            .publicKeyCose(ByteArray.fromBase64Url(publicKeyCose))
+            .signatureCount(signatureCount)
+            .build()
+
+    private fun userHandleForUser(userId: UUID): ByteArray =
+        transaction(db) {
+            UsersTable
+                .selectAll()
+                .where { UsersTable.id eq userId }
+                .single()
+                .let { ByteArray.fromBase64Url(it[UsersTable.passkeyUserHandle]) }
+        }
+
+    private fun mapRow(row: ResultRow) =
+        PasskeyCredential(
+            id = row[PasskeyCredentialsTable.id].value,
+            userId = row[PasskeyCredentialsTable.userId].value,
+            credentialId = row[PasskeyCredentialsTable.credentialId],
+            publicKeyCose = row[PasskeyCredentialsTable.publicKeyCose],
+            signatureCount = row[PasskeyCredentialsTable.signatureCount],
+            transports = row[PasskeyCredentialsTable.transports],
+            nickname = row[PasskeyCredentialsTable.nickname],
+            backupEligible = row[PasskeyCredentialsTable.backupEligible],
+            backedUp = row[PasskeyCredentialsTable.backedUp],
+            createdAt = row[PasskeyCredentialsTable.createdAt],
+            lastUsedAt = row[PasskeyCredentialsTable.lastUsedAt],
+        )
+}

--- a/src/main/kotlin/io/pcast/module/auth/model/User.kt
+++ b/src/main/kotlin/io/pcast/module/auth/model/User.kt
@@ -9,4 +9,5 @@ data class User(
     val passwordHash: String,
     val createdAt: LocalDateTime,
     val tokenVersion: Int = 0,
+    val passkeyUserHandle: String,
 )

--- a/src/main/kotlin/io/pcast/module/auth/model/UserRepository.kt
+++ b/src/main/kotlin/io/pcast/module/auth/model/UserRepository.kt
@@ -11,22 +11,28 @@ import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.jetbrains.exposed.v1.jdbc.update
 import org.koin.core.annotation.Single
+import java.security.SecureRandom
 import java.time.LocalDateTime
+import java.util.Base64
 import java.util.UUID
 
 private const val VARCHAR_MAX_LENGTH = 255
+private const val USER_HANDLE_BYTES = 64
 
 object UsersTable : UUIDTable("users") {
     val email = varchar("email", VARCHAR_MAX_LENGTH).uniqueIndex()
     val passwordHash = varchar("password_hash", VARCHAR_MAX_LENGTH)
     val createdAt = datetime("created_at")
     val tokenVersion = integer("token_version").default(0)
+    val passkeyUserHandle = varchar("passkey_user_handle", VARCHAR_MAX_LENGTH).uniqueIndex()
 }
 
 @Single
 class UserRepository(
     private val db: Database,
 ) {
+    private val secureRandom = SecureRandom()
+
     fun findByEmail(email: String): User? =
         transaction(db) {
             UsersTable
@@ -45,6 +51,15 @@ class UserRepository(
                 .singleOrNull()
         }
 
+    fun findByPasskeyUserHandle(userHandle: String): User? =
+        transaction(db) {
+            UsersTable
+                .selectAll()
+                .where { UsersTable.passkeyUserHandle eq userHandle }
+                .map(::mapRow)
+                .singleOrNull()
+        }
+
     fun create(
         email: String,
         passwordHash: String,
@@ -56,6 +71,7 @@ class UserRepository(
                 passwordHash = passwordHash,
                 createdAt = LocalDateTime.now(),
                 tokenVersion = 0,
+                passkeyUserHandle = generateUserHandle(),
             )
 
         transaction(db) {
@@ -65,6 +81,7 @@ class UserRepository(
                 it[UsersTable.passwordHash] = user.passwordHash
                 it[createdAt] = user.createdAt
                 it[tokenVersion] = user.tokenVersion
+                it[passkeyUserHandle] = user.passkeyUserHandle
             }
         }
 
@@ -89,6 +106,11 @@ class UserRepository(
         }
     }
 
+    private fun generateUserHandle(): String {
+        val bytes = ByteArray(USER_HANDLE_BYTES).also { secureRandom.nextBytes(it) }
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
+    }
+
     private fun mapRow(row: ResultRow) =
         User(
             id = row[UsersTable.id].value,
@@ -96,5 +118,6 @@ class UserRepository(
             passwordHash = row[UsersTable.passwordHash],
             createdAt = row[UsersTable.createdAt],
             tokenVersion = row[UsersTable.tokenVersion],
+            passkeyUserHandle = row[UsersTable.passkeyUserHandle],
         )
 }

--- a/src/main/kotlin/io/pcast/module/auth/passkey/PasskeyCredentialAdapter.kt
+++ b/src/main/kotlin/io/pcast/module/auth/passkey/PasskeyCredentialAdapter.kt
@@ -1,0 +1,46 @@
+package io.pcast.module.auth.passkey
+
+import com.yubico.webauthn.CredentialRepository
+import com.yubico.webauthn.RegisteredCredential
+import com.yubico.webauthn.data.ByteArray
+import com.yubico.webauthn.data.PublicKeyCredentialDescriptor
+import io.pcast.module.auth.model.PasskeyCredentialRepository
+import io.pcast.module.auth.model.UserRepository
+import org.koin.core.annotation.Single
+import java.util.Optional
+
+@Single
+class PasskeyCredentialAdapter(
+    private val userRepository: UserRepository,
+    private val credentialRepository: PasskeyCredentialRepository,
+) : CredentialRepository {
+    override fun getCredentialIdsForUsername(username: String): Set<PublicKeyCredentialDescriptor> =
+        userRepository
+            .findByEmail(username)
+            ?.let { credentialRepository.findDescriptorsByUser(it.id) }
+            ?: emptySet()
+
+    override fun getUserHandleForUsername(username: String): Optional<ByteArray> =
+        userRepository
+            .findByEmail(username)
+            ?.passkeyUserHandle
+            ?.let { ByteArray.fromBase64Url(it) }
+            .let { Optional.ofNullable(it) }
+
+    override fun getUsernameForUserHandle(userHandle: ByteArray): Optional<String> =
+        userRepository
+            .findByPasskeyUserHandle(userHandle.base64Url)
+            ?.email
+            .let { Optional.ofNullable(it) }
+
+    override fun lookup(
+        credentialId: ByteArray,
+        userHandle: ByteArray,
+    ): Optional<RegisteredCredential> =
+        credentialRepository
+            .findRegisteredByCredentialIdAndUserHandle(credentialId, userHandle)
+            .let { Optional.ofNullable(it) }
+
+    override fun lookupAll(credentialId: ByteArray): Set<RegisteredCredential> =
+        credentialRepository.findRegisteredByCredentialId(credentialId)
+}

--- a/src/main/kotlin/io/pcast/module/auth/passkey/PasskeyService.kt
+++ b/src/main/kotlin/io/pcast/module/auth/passkey/PasskeyService.kt
@@ -7,14 +7,20 @@ import com.yubico.webauthn.RelyingParty
 import com.yubico.webauthn.StartAssertionOptions
 import com.yubico.webauthn.StartRegistrationOptions
 import com.yubico.webauthn.data.AttestationConveyancePreference
+import com.yubico.webauthn.data.AuthenticatorAssertionResponse
+import com.yubico.webauthn.data.AuthenticatorAttestationResponse
 import com.yubico.webauthn.data.AuthenticatorSelectionCriteria
 import com.yubico.webauthn.data.ByteArray
+import com.yubico.webauthn.data.ClientAssertionExtensionOutputs
+import com.yubico.webauthn.data.ClientRegistrationExtensionOutputs
 import com.yubico.webauthn.data.PublicKeyCredential
 import com.yubico.webauthn.data.PublicKeyCredentialCreationOptions
 import com.yubico.webauthn.data.RelyingPartyIdentity
 import com.yubico.webauthn.data.ResidentKeyRequirement
 import com.yubico.webauthn.data.UserIdentity
 import com.yubico.webauthn.data.UserVerificationRequirement
+import com.yubico.webauthn.exception.AssertionFailedException
+import com.yubico.webauthn.exception.RegistrationFailedException
 import io.pcast.config.Configuration
 import io.pcast.error.AbortError
 import io.pcast.error.HttpError
@@ -98,14 +104,7 @@ class PasskeyService(
 
         if (challenge.userId != userId) throw AbortError(HttpError.Unauthorized, "Unauthorized")
 
-        val result =
-            relyingParty.finishRegistration(
-                FinishRegistrationOptions
-                    .builder()
-                    .request(PublicKeyCredentialCreationOptions.fromJson(challenge.requestJson))
-                    .response(response)
-                    .build(),
-            )
+        val result = finishRegistrationOrAbort(challenge.requestJson, response)
 
         return credentialRepository.create(
             userId = userId,
@@ -146,14 +145,7 @@ class PasskeyService(
         val response = parseAssertionResponse(responseJson)
         val challenge =
             consumeChallenge(response.response.clientData.challenge.base64Url, PasskeyChallengeType.Authentication)
-        val result =
-            relyingParty.finishAssertion(
-                FinishAssertionOptions
-                    .builder()
-                    .request(AssertionRequest.fromJson(challenge.requestJson))
-                    .response(response)
-                    .build(),
-            )
+        val result = finishAssertionOrAbort(challenge.requestJson, response)
 
         if (!result.isSuccess) throw AbortError(HttpError.Unauthorized, "Unauthorized")
 
@@ -191,4 +183,40 @@ class PasskeyService(
     private fun parseAssertionResponse(responseJson: String) =
         runCatching { PublicKeyCredential.parseAssertionResponseJson(responseJson) }
             .getOrElse { throw AbortError(HttpError.BadRequest, "Invalid passkey authentication response", it) }
+
+    private fun finishRegistrationOrAbort(
+        requestJson: String,
+        response: PublicKeyCredential<AuthenticatorAttestationResponse, ClientRegistrationExtensionOutputs>,
+    ) = runCatching {
+        relyingParty.finishRegistration(
+            FinishRegistrationOptions
+                .builder()
+                .request(PublicKeyCredentialCreationOptions.fromJson(requestJson))
+                .response(response)
+                .build(),
+        )
+    }.getOrElse { cause ->
+        if (cause is RegistrationFailedException) {
+            throw AbortError(HttpError.BadRequest, "Invalid passkey registration response", cause)
+        }
+        throw cause
+    }
+
+    private fun finishAssertionOrAbort(
+        requestJson: String,
+        response: PublicKeyCredential<AuthenticatorAssertionResponse, ClientAssertionExtensionOutputs>,
+    ) = runCatching {
+        relyingParty.finishAssertion(
+            FinishAssertionOptions
+                .builder()
+                .request(AssertionRequest.fromJson(requestJson))
+                .response(response)
+                .build(),
+        )
+    }.getOrElse { cause ->
+        if (cause is AssertionFailedException) {
+            throw AbortError(HttpError.Unauthorized, "Unauthorized", cause)
+        }
+        throw cause
+    }
 }

--- a/src/main/kotlin/io/pcast/module/auth/passkey/PasskeyService.kt
+++ b/src/main/kotlin/io/pcast/module/auth/passkey/PasskeyService.kt
@@ -1,0 +1,194 @@
+package io.pcast.module.auth.passkey
+
+import com.yubico.webauthn.AssertionRequest
+import com.yubico.webauthn.FinishAssertionOptions
+import com.yubico.webauthn.FinishRegistrationOptions
+import com.yubico.webauthn.RelyingParty
+import com.yubico.webauthn.StartAssertionOptions
+import com.yubico.webauthn.StartRegistrationOptions
+import com.yubico.webauthn.data.AttestationConveyancePreference
+import com.yubico.webauthn.data.AuthenticatorSelectionCriteria
+import com.yubico.webauthn.data.ByteArray
+import com.yubico.webauthn.data.PublicKeyCredential
+import com.yubico.webauthn.data.PublicKeyCredentialCreationOptions
+import com.yubico.webauthn.data.RelyingPartyIdentity
+import com.yubico.webauthn.data.ResidentKeyRequirement
+import com.yubico.webauthn.data.UserIdentity
+import com.yubico.webauthn.data.UserVerificationRequirement
+import io.pcast.config.Configuration
+import io.pcast.error.AbortError
+import io.pcast.error.HttpError
+import io.pcast.module.auth.AuthService
+import io.pcast.module.auth.model.PasskeyChallengeRepository
+import io.pcast.module.auth.model.PasskeyChallengeType
+import io.pcast.module.auth.model.PasskeyCredential
+import io.pcast.module.auth.model.PasskeyCredentialRepository
+import io.pcast.module.auth.model.UserRepository
+import io.pcast.module.auth.response.TokenResponse
+import org.koin.core.annotation.Single
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Single
+class PasskeyService(
+    private val config: Configuration,
+    private val authService: AuthService,
+    private val userRepository: UserRepository,
+    private val credentialRepository: PasskeyCredentialRepository,
+    private val challengeRepository: PasskeyChallengeRepository,
+    credentialAdapter: PasskeyCredentialAdapter,
+) {
+    private val relyingParty =
+        RelyingParty
+            .builder()
+            .identity(
+                RelyingPartyIdentity
+                    .builder()
+                    .id(config.passkey.rpId)
+                    .name(config.passkey.rpName)
+                    .build(),
+            ).credentialRepository(credentialAdapter)
+            .origins(config.passkey.allowedOrigins.toSet())
+            .attestationConveyancePreference(AttestationConveyancePreference.NONE)
+            .allowUntrustedAttestation(true)
+            .validateSignatureCounter(true)
+            .build()
+
+    fun startRegistration(userId: UUID): String {
+        val user = userRepository.findById(userId) ?: throw AbortError(HttpError.Unauthorized, "Unauthorized")
+        val request =
+            relyingParty.startRegistration(
+                StartRegistrationOptions
+                    .builder()
+                    .user(
+                        UserIdentity
+                            .builder()
+                            .name(user.email)
+                            .displayName(user.email)
+                            .id(ByteArray.fromBase64Url(user.passkeyUserHandle))
+                            .build(),
+                    ).authenticatorSelection(
+                        AuthenticatorSelectionCriteria
+                            .builder()
+                            .residentKey(ResidentKeyRequirement.REQUIRED)
+                            .userVerification(UserVerificationRequirement.REQUIRED)
+                            .build(),
+                    ).timeout(config.passkey.timeoutMillis)
+                    .build(),
+            )
+
+        challengeRepository.create(
+            userId = user.id,
+            type = PasskeyChallengeType.Registration,
+            challenge = request.challenge.base64Url,
+            requestJson = request.toJson(),
+            expiresAt = LocalDateTime.now().plusSeconds(config.passkey.challengeTtlSeconds),
+        )
+
+        return request.toCredentialsCreateJson()
+    }
+
+    fun finishRegistration(
+        userId: UUID,
+        responseJson: String,
+    ): PasskeyCredential {
+        val response = parseRegistrationResponse(responseJson)
+        val challenge =
+            consumeChallenge(response.response.clientData.challenge.base64Url, PasskeyChallengeType.Registration)
+
+        if (challenge.userId != userId) throw AbortError(HttpError.Unauthorized, "Unauthorized")
+
+        val result =
+            relyingParty.finishRegistration(
+                FinishRegistrationOptions
+                    .builder()
+                    .request(PublicKeyCredentialCreationOptions.fromJson(challenge.requestJson))
+                    .response(response)
+                    .build(),
+            )
+
+        return credentialRepository.create(
+            userId = userId,
+            credentialId = result.keyId.id.base64Url,
+            publicKeyCose = result.publicKeyCose.base64Url,
+            signatureCount = result.signatureCount,
+            transports = response.response.transports.joinToString(",") { it.id },
+            nickname = null,
+            backupEligible = result.isBackupEligible,
+            backedUp = result.isBackedUp,
+        )
+    }
+
+    fun startAuthentication(email: String?): String {
+        val builder =
+            StartAssertionOptions
+                .builder()
+                .userVerification(UserVerificationRequirement.REQUIRED)
+                .timeout(config.passkey.timeoutMillis)
+
+        if (!email.isNullOrBlank()) {
+            userRepository.findByEmail(email)?.let { builder.username(it.email) }
+        }
+
+        val request = relyingParty.startAssertion(builder.build())
+        challengeRepository.create(
+            userId = email?.takeIf { it.isNotBlank() }?.let { userRepository.findByEmail(it)?.id },
+            type = PasskeyChallengeType.Authentication,
+            challenge = request.publicKeyCredentialRequestOptions.challenge.base64Url,
+            requestJson = request.toJson(),
+            expiresAt = LocalDateTime.now().plusSeconds(config.passkey.challengeTtlSeconds),
+        )
+
+        return request.toCredentialsGetJson()
+    }
+
+    fun finishAuthentication(responseJson: String): TokenResponse {
+        val response = parseAssertionResponse(responseJson)
+        val challenge =
+            consumeChallenge(response.response.clientData.challenge.base64Url, PasskeyChallengeType.Authentication)
+        val result =
+            relyingParty.finishAssertion(
+                FinishAssertionOptions
+                    .builder()
+                    .request(AssertionRequest.fromJson(challenge.requestJson))
+                    .response(response)
+                    .build(),
+            )
+
+        if (!result.isSuccess) throw AbortError(HttpError.Unauthorized, "Unauthorized")
+
+        credentialRepository.updateAfterAuthentication(
+            credentialId = result.credential.credentialId.base64Url,
+            signatureCount = result.signatureCount,
+            backupEligible = result.isBackupEligible,
+            backedUp = result.isBackedUp,
+        )
+
+        val user =
+            userRepository.findByEmail(result.username)
+                ?: throw AbortError(HttpError.Unauthorized, "Unauthorized")
+
+        return authService.issueTokenPair(user)
+    }
+
+    fun listCredentials(userId: UUID): List<PasskeyCredential> = credentialRepository.listByUser(userId)
+
+    fun deleteCredential(
+        userId: UUID,
+        credentialId: UUID,
+    ): Boolean = credentialRepository.deleteForUser(userId, credentialId)
+
+    private fun consumeChallenge(
+        challenge: String,
+        type: PasskeyChallengeType,
+    ) = challengeRepository.consume(challenge, type)
+        ?: throw AbortError(HttpError.Unauthorized, "Passkey challenge expired or already used")
+
+    private fun parseRegistrationResponse(responseJson: String) =
+        runCatching { PublicKeyCredential.parseRegistrationResponseJson(responseJson) }
+            .getOrElse { throw AbortError(HttpError.BadRequest, "Invalid passkey registration response", it) }
+
+    private fun parseAssertionResponse(responseJson: String) =
+        runCatching { PublicKeyCredential.parseAssertionResponseJson(responseJson) }
+            .getOrElse { throw AbortError(HttpError.BadRequest, "Invalid passkey authentication response", it) }
+}

--- a/src/main/kotlin/io/pcast/module/auth/passkey/request/PasskeyAuthenticationOptionsRequest.kt
+++ b/src/main/kotlin/io/pcast/module/auth/passkey/request/PasskeyAuthenticationOptionsRequest.kt
@@ -1,0 +1,8 @@
+package io.pcast.module.auth.passkey.request
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PasskeyAuthenticationOptionsRequest(
+    val email: String? = null,
+)

--- a/src/main/kotlin/io/pcast/module/auth/passkey/response/PasskeyCredentialResponse.kt
+++ b/src/main/kotlin/io/pcast/module/auth/passkey/response/PasskeyCredentialResponse.kt
@@ -1,0 +1,34 @@
+package io.pcast.module.auth.passkey.response
+
+import io.pcast.module.auth.model.PasskeyCredential
+import io.pcast.serializer.LocalDateTimeSerializer
+import io.pcast.serializer.UuidSerializer
+import kotlinx.serialization.Serializable
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Serializable
+data class PasskeyCredentialResponse(
+    @Serializable(with = UuidSerializer::class)
+    val id: UUID,
+    val credentialId: String,
+    val transports: String?,
+    val nickname: String?,
+    val backupEligible: Boolean?,
+    val backedUp: Boolean?,
+    @Serializable(with = LocalDateTimeSerializer::class)
+    val createdAt: LocalDateTime,
+    @Serializable(with = LocalDateTimeSerializer::class)
+    val lastUsedAt: LocalDateTime?,
+) {
+    constructor(credential: PasskeyCredential) : this(
+        id = credential.id,
+        credentialId = credential.credentialId,
+        transports = credential.transports,
+        nickname = credential.nickname,
+        backupEligible = credential.backupEligible,
+        backedUp = credential.backedUp,
+        createdAt = credential.createdAt,
+        lastUsedAt = credential.lastUsedAt,
+    )
+}

--- a/src/main/kotlin/io/pcast/plugins/RateLimit.kt
+++ b/src/main/kotlin/io/pcast/plugins/RateLimit.kt
@@ -16,6 +16,7 @@ import kotlin.time.Duration.Companion.minutes
  */
 val RATE_LIMIT_LOGIN = RateLimitName("login")
 val RATE_LIMIT_REFRESH = RateLimitName("refresh")
+val RATE_LIMIT_PASSKEY = RateLimitName("passkey")
 
 fun Application.configureRateLimit() {
     install(RateLimit) {
@@ -32,6 +33,14 @@ fun Application.configureRateLimit() {
         // Refresh: 30 attempts per minute per IP address.
         register(RATE_LIMIT_REFRESH) {
             rateLimiter(limit = 30, refillPeriod = 1.minutes)
+            requestKey { call ->
+                call.request.local.remoteAddress
+            }
+        }
+
+        // Passkey ceremonies are cheaper than bcrypt login but still user-visible auth attempts.
+        register(RATE_LIMIT_PASSKEY) {
+            rateLimiter(limit = 20, refillPeriod = 1.minutes)
             requestKey { call ->
                 call.request.local.remoteAddress
             }

--- a/src/main/kotlin/io/pcast/plugins/Validation.kt
+++ b/src/main/kotlin/io/pcast/plugins/Validation.kt
@@ -4,6 +4,7 @@ import io.ktor.server.application.Application
 import io.ktor.server.application.install
 import io.ktor.server.plugins.requestvalidation.RequestValidation
 import io.ktor.server.plugins.requestvalidation.ValidationResult
+import io.pcast.module.auth.passkey.request.PasskeyAuthenticationOptionsRequest
 import io.pcast.module.auth.request.LoginRequest
 import io.pcast.module.feed.request.FeedRequest
 import io.pcast.module.sync.request.ValidateSyncPhraseRequest
@@ -24,6 +25,15 @@ fun Application.configureValidation() {
                 errors += "password: exceeds maximum of $PASSWORD_MAX_BYTES bytes"
             }
             if (errors.isEmpty()) ValidationResult.Valid else ValidationResult.Invalid(errors.joinToString("; "))
+        }
+
+        validate<PasskeyAuthenticationOptionsRequest> { req ->
+            val email = req.email
+            if (email != null && email.isNotBlank() && !EMAIL_REGEX.matches(email)) {
+                ValidationResult.Invalid("email: invalid format")
+            } else {
+                ValidationResult.Valid
+            }
         }
 
         validate<FeedRequest> { req ->

--- a/src/main/resources/app.conf
+++ b/src/main/resources/app.conf
@@ -12,3 +12,11 @@ jwt {
   accessTokenExpireMinutes = 60
   refreshTokenExpireDays = 30
 }
+
+passkey {
+  rpId = "localhost"
+  rpName = "pcast"
+  allowedOrigins = ["http://localhost:3000"]
+  challengeTtlSeconds = 300
+  timeoutMillis = 60000
+}

--- a/src/main/resources/db/migration/V6__PASSKEYS.sql
+++ b/src/main/resources/db/migration/V6__PASSKEYS.sql
@@ -1,0 +1,39 @@
+ALTER TABLE users ADD COLUMN passkey_user_handle VARCHAR(86);
+
+UPDATE users
+SET passkey_user_handle = replace(gen_random_uuid()::text, '-', '') || replace(gen_random_uuid()::text, '-', '')
+WHERE passkey_user_handle IS NULL;
+
+ALTER TABLE users ALTER COLUMN passkey_user_handle SET NOT NULL;
+ALTER TABLE users ADD CONSTRAINT users_passkey_user_handle_unique UNIQUE (passkey_user_handle);
+
+CREATE TABLE passkey_credentials (
+    id UUID PRIMARY KEY,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    credential_id VARCHAR(1024) NOT NULL UNIQUE,
+    public_key_cose TEXT NOT NULL,
+    signature_count BIGINT NOT NULL DEFAULT 0,
+    transports VARCHAR(255),
+    nickname VARCHAR(255),
+    backup_eligible BOOLEAN,
+    backed_up BOOLEAN,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    last_used_at TIMESTAMP
+);
+
+CREATE INDEX passkey_credentials_user_idx ON passkey_credentials(user_id);
+CREATE INDEX passkey_credentials_credential_idx ON passkey_credentials(credential_id);
+
+CREATE TABLE passkey_challenges (
+    id UUID PRIMARY KEY,
+    user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+    type VARCHAR(32) NOT NULL,
+    challenge VARCHAR(512) NOT NULL UNIQUE,
+    request_json TEXT NOT NULL,
+    expires_at TIMESTAMP NOT NULL,
+    consumed_at TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX passkey_challenges_challenge_idx ON passkey_challenges(challenge);
+CREATE INDEX passkey_challenges_expires_idx ON passkey_challenges(expires_at);

--- a/src/main/resources/db/migration/V6__PASSKEYS.sql
+++ b/src/main/resources/db/migration/V6__PASSKEYS.sql
@@ -37,3 +37,4 @@ CREATE TABLE passkey_challenges (
 
 CREATE INDEX passkey_challenges_challenge_idx ON passkey_challenges(challenge);
 CREATE INDEX passkey_challenges_expires_idx ON passkey_challenges(expires_at);
+CREATE INDEX passkey_challenges_consumed_idx ON passkey_challenges(consumed_at);

--- a/src/test/kotlin/io/pcast/module/auth/api/AuthRouterTest.kt
+++ b/src/test/kotlin/io/pcast/module/auth/api/AuthRouterTest.kt
@@ -2,10 +2,14 @@ package io.pcast.module.auth.api
 
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
+import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
@@ -16,6 +20,8 @@ import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.testing.testApplication
 import io.pcast.module.AppModule
 import io.pcast.module.auth.AuthService
+import io.pcast.module.auth.passkey.request.PasskeyAuthenticationOptionsRequest
+import io.pcast.module.auth.passkey.response.PasskeyCredentialResponse
 import io.pcast.module.auth.request.LoginRequest
 import io.pcast.module.auth.request.RefreshRequest
 import io.pcast.module.auth.response.TokenResponse
@@ -205,7 +211,87 @@ internal class AuthRouterTest : KoinTest {
                 }
         }
 
+    @Test
+    fun testPasskeyRegistrationOptionsRequiresAuthentication() =
+        testApplication {
+            val client = configureServerAndGetClient()
+
+            client
+                .post("/api/auth/passkeys/registration/options") {
+                    header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                }.expect {
+                    assertEquals(HttpStatusCode.Unauthorized, status)
+                }
+        }
+
+    @Test
+    fun testPasskeyRegistrationOptionsSuccess() =
+        testApplication {
+            val client = configureServerAndGetClient()
+            val loginResponse = login(client)
+
+            client
+                .post("/api/auth/passkeys/registration/options") {
+                    bearerAuth(loginResponse.accessToken)
+                    header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                }.expect {
+                    assertEquals(HttpStatusCode.OK, status)
+                    assertTrue(bodyAsText().contains("\"publicKey\""))
+                }
+        }
+
+    @Test
+    fun testListPasskeysStartsEmpty() =
+        testApplication {
+            val client = configureServerAndGetClient()
+            val loginResponse = login(client)
+
+            client
+                .get("/api/auth/passkeys") {
+                    bearerAuth(loginResponse.accessToken)
+                }.expect {
+                    assertEquals(HttpStatusCode.OK, status)
+                    assertEquals(emptyList<PasskeyCredentialResponse>(), body<List<PasskeyCredentialResponse>>())
+                }
+        }
+
+    @Test
+    fun testPasskeyAuthenticationOptionsSuccess() =
+        testApplication {
+            val client = configureServerAndGetClient()
+
+            client
+                .post("/api/auth/passkeys/authentication/options") {
+                    header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                    setBody(PasskeyAuthenticationOptionsRequest(TEST_EMAIL))
+                }.expect {
+                    assertEquals(HttpStatusCode.OK, status)
+                    assertTrue(bodyAsText().contains("\"publicKey\""))
+                }
+        }
+
+    @Test
+    fun testPasskeyAuthenticationOptionsInvalidEmail() =
+        testApplication {
+            val client = configureServerAndGetClient()
+
+            client
+                .post("/api/auth/passkeys/authentication/options") {
+                    header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                    setBody(PasskeyAuthenticationOptionsRequest("invalid-email"))
+                }.expect {
+                    assertEquals(HttpStatusCode.BadRequest, status)
+                }
+        }
+
     private inline fun HttpResponse.expect(test: HttpResponse.() -> Unit) = apply(test)
+
+    private suspend fun login(client: HttpClient): TokenResponse =
+        client
+            .post("/api/auth/login") {
+                header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                setBody(LoginRequest(TEST_EMAIL, TEST_PASSWORD))
+            }.body()
 
     private fun ApplicationTestBuilder.configureServerAndGetClient(): HttpClient {
         application {

--- a/src/test/kotlin/io/pcast/module/auth/model/PasskeyChallengeRepositoryTest.kt
+++ b/src/test/kotlin/io/pcast/module/auth/model/PasskeyChallengeRepositoryTest.kt
@@ -1,0 +1,159 @@
+package io.pcast.module.auth.model
+
+import io.pcast.module.AppModule
+import io.pcast.module.testConfigModule
+import io.pcast.module.testDbModule
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.koin.dsl.koinApplication
+import org.koin.ksp.generated.module
+import java.time.LocalDateTime
+import java.util.UUID
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+private const val REQUEST_JSON = """{"publicKey":{"challenge":"test"}}"""
+private const val CONCURRENT_ATTEMPTS = 8
+
+internal class PasskeyChallengeRepositoryTest {
+    @Test
+    fun testConsumeReturnsChallengeOnce() {
+        withRepository { _, repository ->
+            val challenge = "consume-once-${UUID.randomUUID()}"
+
+            repository.create(
+                userId = null,
+                type = PasskeyChallengeType.Authentication,
+                challenge = challenge,
+                requestJson = REQUEST_JSON,
+                expiresAt = LocalDateTime.now().plusMinutes(5),
+            )
+
+            val consumed = repository.consume(challenge, PasskeyChallengeType.Authentication)
+            val replay = repository.consume(challenge, PasskeyChallengeType.Authentication)
+
+            assertNotNull(consumed)
+            assertEquals(REQUEST_JSON, consumed.requestJson)
+            assertNull(replay)
+        }
+    }
+
+    @Test
+    fun testConsumeRejectsExpiredChallenge() {
+        withRepository { _, repository ->
+            val challenge = "expired-${UUID.randomUUID()}"
+
+            repository.create(
+                userId = null,
+                type = PasskeyChallengeType.Authentication,
+                challenge = challenge,
+                requestJson = REQUEST_JSON,
+                expiresAt = LocalDateTime.now().minusMinutes(1),
+            )
+
+            assertNull(repository.consume(challenge, PasskeyChallengeType.Authentication))
+        }
+    }
+
+    @Test
+    fun testConcurrentConsumeOnlySucceedsOnce() {
+        withRepository { _, repository ->
+            val challenge = "concurrent-${UUID.randomUUID()}"
+
+            repository.create(
+                userId = null,
+                type = PasskeyChallengeType.Authentication,
+                challenge = challenge,
+                requestJson = REQUEST_JSON,
+                expiresAt = LocalDateTime.now().plusMinutes(5),
+            )
+
+            val executor = Executors.newFixedThreadPool(CONCURRENT_ATTEMPTS)
+            val ready = CountDownLatch(CONCURRENT_ATTEMPTS)
+            val start = CountDownLatch(1)
+
+            val futures =
+                (1..CONCURRENT_ATTEMPTS).map {
+                    executor.submit<PasskeyChallenge?> {
+                        ready.countDown()
+                        start.await()
+                        repository.consume(challenge, PasskeyChallengeType.Authentication)
+                    }
+                }
+
+            assertTrue(ready.await(5, TimeUnit.SECONDS))
+            start.countDown()
+
+            val results = futures.map { it.get(5, TimeUnit.SECONDS) }
+            executor.shutdown()
+
+            assertEquals(1, results.count { it != null })
+        }
+    }
+
+    @Test
+    fun testCreatePurgesExpiredAndConsumedChallenges() {
+        withRepository { db, repository ->
+            val consumedChallenge = "consumed-${UUID.randomUUID()}"
+
+            repository.create(
+                userId = null,
+                type = PasskeyChallengeType.Authentication,
+                challenge = "expired-${UUID.randomUUID()}",
+                requestJson = REQUEST_JSON,
+                expiresAt = LocalDateTime.now().minusMinutes(1),
+            )
+            repository.create(
+                userId = null,
+                type = PasskeyChallengeType.Authentication,
+                challenge = consumedChallenge,
+                requestJson = REQUEST_JSON,
+                expiresAt = LocalDateTime.now().plusMinutes(5),
+            )
+            repository.consume(consumedChallenge, PasskeyChallengeType.Authentication)
+            repository.create(
+                userId = null,
+                type = PasskeyChallengeType.Authentication,
+                challenge = "active-${UUID.randomUUID()}",
+                requestJson = REQUEST_JSON,
+                expiresAt = LocalDateTime.now().plusMinutes(5),
+            )
+
+            val remainingRows =
+                transaction(db) {
+                    PasskeyChallengesTable
+                        .selectAll()
+                        .map { row ->
+                            row[PasskeyChallengesTable.expiresAt] to row[PasskeyChallengesTable.consumedAt]
+                        }
+                }
+
+            assertEquals(1, remainingRows.size)
+            assertTrue(remainingRows.single().first.isAfter(LocalDateTime.now()))
+            assertNull(remainingRows.single().second)
+        }
+    }
+
+    private fun withRepository(block: (Database, PasskeyChallengeRepository) -> Unit) {
+        val koinApplication =
+            koinApplication {
+                modules(testConfigModule, testDbModule, AppModule().module)
+            }
+
+        try {
+            block(
+                koinApplication.koin.get(),
+                koinApplication.koin.get(),
+            )
+        } finally {
+            koinApplication.close()
+        }
+    }
+}


### PR DESCRIPTION
**Summary**

Adds passkey/WebAuthn support to authentication and hardens the passkey challenge lifecycle.

**Changes**

- Added Yubico WebAuthn server support and passkey configuration.
- Added DB schema for passkey user handles, credentials, and persisted challenges.
- Added passkey registration, authentication, list, and delete endpoints.
- Reused existing JWT/refresh-token issuance after successful passkey authentication.
- Made passkey challenges atomic, single-use, expiring, and opportunistically cleaned up.
- Mapped WebAuthn verification failures to controlled 400/401 responses.
