### PR TITLE
feat: roadmap Phase 0 — quick-win client features

### DIFF
--- a/src/main/kotlin/io/pcast/error/Error.kt
+++ b/src/main/kotlin/io/pcast/error/Error.kt
@@ -15,6 +15,8 @@ sealed class HttpError(
 
     data object Unauthorized : HttpError(statusCode = HttpStatusCode.Unauthorized)
 
+    data object Conflict : HttpError(statusCode = HttpStatusCode.Conflict)
+
     data object NotImplemented : HttpError(statusCode = HttpStatusCode.NotImplemented)
 }
 

--- a/src/main/kotlin/io/pcast/module/auth/AuthService.kt
+++ b/src/main/kotlin/io/pcast/module/auth/AuthService.kt
@@ -2,6 +2,8 @@ package io.pcast.module.auth
 
 import at.favre.lib.crypto.bcrypt.BCrypt
 import io.pcast.config.Configuration
+import io.pcast.error.AbortError
+import io.pcast.error.HttpError
 import io.pcast.extensions.jwt
 import io.pcast.extensions.withExpiresIn
 import io.pcast.module.auth.model.RefreshTokenRepository
@@ -66,6 +68,24 @@ class AuthService(
         // Invalidate all outstanding access tokens by bumping the token version.
         userRepository.incrementTokenVersion(storedToken.userId)
         return refreshTokenRepository.deleteByTokenHash(tokenHash)
+    }
+
+    /**
+     * Registers a new account and immediately issues a token pair (auto-login).
+     * Password/email format are enforced upstream by RequestValidation; a duplicate
+     * email is rejected here with 409 Conflict (the users.email unique index is the
+     * authoritative guard).
+     */
+    fun register(
+        email: String,
+        password: String,
+    ): TokenResponse {
+        if (userRepository.findByEmail(email) != null) {
+            throw AbortError(HttpError.Conflict, "Email already registered")
+        }
+
+        val user = createUser(email, password)
+        return issueTokenPair(user)
     }
 
     fun createUser(

--- a/src/main/kotlin/io/pcast/module/auth/api/AuthRouter.kt
+++ b/src/main/kotlin/io/pcast/module/auth/api/AuthRouter.kt
@@ -23,10 +23,12 @@ import io.pcast.module.auth.passkey.request.PasskeyAuthenticationOptionsRequest
 import io.pcast.module.auth.passkey.response.PasskeyCredentialResponse
 import io.pcast.module.auth.request.LoginRequest
 import io.pcast.module.auth.request.RefreshRequest
+import io.pcast.module.auth.request.RegisterRequest
 import io.pcast.plugins.JWT_AUTH_NAME
 import io.pcast.plugins.RATE_LIMIT_LOGIN
 import io.pcast.plugins.RATE_LIMIT_PASSKEY
 import io.pcast.plugins.RATE_LIMIT_REFRESH
+import io.pcast.plugins.RATE_LIMIT_REGISTER
 import org.koin.ktor.ext.inject
 import org.slf4j.LoggerFactory
 import java.util.UUID
@@ -36,6 +38,17 @@ private val log = LoggerFactory.getLogger("AuthRouter")
 fun Route.registerAuthRoutes() {
     val authService by inject<AuthService>()
     val passkeyService by inject<PasskeyService>()
+
+    rateLimit(RATE_LIMIT_REGISTER) {
+        post("/auth/register") {
+            val request = call.receive<RegisterRequest>()
+
+            val tokenResponse = authService.register(request.email, request.password)
+
+            call.response.header(HttpHeaders.CacheControl, "no-store")
+            call.respond(HttpStatusCode.Created, tokenResponse)
+        }
+    }
 
     rateLimit(RATE_LIMIT_LOGIN) {
         post("/auth/login") {

--- a/src/main/kotlin/io/pcast/module/auth/request/RegisterRequest.kt
+++ b/src/main/kotlin/io/pcast/module/auth/request/RegisterRequest.kt
@@ -1,0 +1,9 @@
+package io.pcast.module.auth.request
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RegisterRequest(
+    val email: String,
+    val password: String,
+)

--- a/src/main/kotlin/io/pcast/module/feed/FeedService.kt
+++ b/src/main/kotlin/io/pcast/module/feed/FeedService.kt
@@ -50,4 +50,12 @@ class FeedService(
         val updated = repository.update(feed, ownerId = userId)
         if (!updated) throw AbortError(HttpError.NotFound, "No feed found")
     }
+
+    fun deleteFeed(
+        nanoId: String,
+        userId: UUID,
+    ) {
+        val deleted = repository.deleteByNanoId(nanoId, ownerId = userId)
+        if (!deleted) throw AbortError(HttpError.NotFound, "No feed found")
+    }
 }

--- a/src/main/kotlin/io/pcast/module/feed/FeedService.kt
+++ b/src/main/kotlin/io/pcast/module/feed/FeedService.kt
@@ -37,6 +37,8 @@ class FeedService(
         userId: UUID,
     ): Feed = repository.findByNanoId(nanoId, userId)
 
+    fun exportOpml(userId: UUID): OpmlFile = OpmlFile.fromFeeds(repository.findAll(userId))
+
     fun addFeed(
         request: FeedRequest,
         userId: UUID,

--- a/src/main/kotlin/io/pcast/module/feed/FeedService.kt
+++ b/src/main/kotlin/io/pcast/module/feed/FeedService.kt
@@ -9,11 +9,28 @@ import io.pcast.module.feed.request.FeedRequest
 import org.koin.core.annotation.Single
 import java.util.UUID
 
+data class FeedPage(
+    val feeds: List<Feed>,
+    val total: Long,
+)
+
 @Single
 class FeedService(
     private val repository: FeedRepository,
 ) {
     fun getFeeds(userId: UUID): List<Feed> = repository.findAll(userId)
+
+    fun getFeeds(
+        userId: UUID,
+        page: Int,
+        pageSize: Int,
+    ): FeedPage {
+        val offset = (page - 1) * pageSize
+        return FeedPage(
+            feeds = repository.findPage(userId, limit = pageSize, offset = offset),
+            total = repository.count(userId),
+        )
+    }
 
     fun getFeed(
         nanoId: String,

--- a/src/main/kotlin/io/pcast/module/feed/api/FeedRouter.kt
+++ b/src/main/kotlin/io/pcast/module/feed/api/FeedRouter.kt
@@ -1,10 +1,12 @@
 package io.pcast.module.feed.api
 
+import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.request.receive
 import io.ktor.server.request.receiveText
 import io.ktor.server.response.header
 import io.ktor.server.response.respond
+import io.ktor.server.response.respondText
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.delete
 import io.ktor.server.routing.get
@@ -18,6 +20,7 @@ import io.pcast.module.feed.opml.OpmlFile
 import io.pcast.module.feed.request.FeedRequest
 import io.pcast.module.feed.response.FeedResponse
 import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
 import nl.adaptivity.xmlutil.serialization.XML
 import org.koin.ktor.ext.inject
 
@@ -78,6 +81,13 @@ fun Route.registerFeedRoutes() {
         service.deleteFeed(id, userId)
 
         call.respond(HttpStatusCode.NoContent)
+    }
+
+    get("/feeds/opml") {
+        val userId = call.userId()
+        val opml = service.exportOpml(userId)
+
+        call.respondText(OPML_XML.encodeToString(opml), ContentType.Application.Xml, HttpStatusCode.OK)
     }
 
     post("/feeds/opml") {

--- a/src/main/kotlin/io/pcast/module/feed/api/FeedRouter.kt
+++ b/src/main/kotlin/io/pcast/module/feed/api/FeedRouter.kt
@@ -5,6 +5,7 @@ import io.ktor.server.request.receive
 import io.ktor.server.request.receiveText
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
+import io.ktor.server.routing.delete
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.put
@@ -63,6 +64,15 @@ fun Route.registerFeedRoutes() {
         val request = call.receive<FeedRequest>()
 
         service.updateFeed(id, request, userId)
+
+        call.respond(HttpStatusCode.NoContent)
+    }
+
+    delete("/feeds/{id}") {
+        val id = call.parameters["id"] ?: throw AbortError(HttpError.BadRequest, "Feed ID must be provided")
+        val userId = call.userId()
+
+        service.deleteFeed(id, userId)
 
         call.respond(HttpStatusCode.NoContent)
     }

--- a/src/main/kotlin/io/pcast/module/feed/api/FeedRouter.kt
+++ b/src/main/kotlin/io/pcast/module/feed/api/FeedRouter.kt
@@ -3,6 +3,7 @@ package io.pcast.module.feed.api
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.request.receive
 import io.ktor.server.request.receiveText
+import io.ktor.server.response.header
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.delete
@@ -20,6 +21,10 @@ import kotlinx.serialization.decodeFromString
 import nl.adaptivity.xmlutil.serialization.XML
 import org.koin.ktor.ext.inject
 
+private const val DEFAULT_PAGE = 1
+private const val DEFAULT_PAGE_SIZE = 50
+private const val MAX_PAGE_SIZE = 100
+
 private val OPML_XML =
     XML {
         repairNamespaces = true
@@ -33,13 +38,11 @@ fun Route.registerFeedRoutes() {
 
     get("/feeds") {
         val userId = call.userId()
-        val feeds = service.getFeeds(userId)
+        val (page, pageSize) = call.paginationParams()
+        val result = service.getFeeds(userId, page, pageSize)
 
-        if (feeds.isNotEmpty()) {
-            call.respond(feeds.map(::FeedResponse))
-        } else {
-            throw AbortError(HttpError.NoContent, "No feeds found.")
-        }
+        call.response.header("X-Total-Count", result.total.toString())
+        call.respond(result.feeds.map(::FeedResponse))
     }
 
     post("/feeds") {
@@ -84,6 +87,31 @@ fun Route.registerFeedRoutes() {
 
         call.respond(HttpStatusCode.Created, feeds)
     }
+}
+
+/**
+ * Parses 1-based `page` and `pageSize` query parameters, falling back to defaults when absent.
+ * Rejects non-numeric values, page < 1, pageSize < 1, and pageSize beyond [MAX_PAGE_SIZE] with 400.
+ */
+private fun io.ktor.server.application.ApplicationCall.paginationParams(): Pair<Int, Int> {
+    val page = parsePositiveIntParam("page", DEFAULT_PAGE)
+    val pageSize = parsePositiveIntParam("pageSize", DEFAULT_PAGE_SIZE)
+
+    if (pageSize > MAX_PAGE_SIZE) {
+        throw AbortError(HttpError.BadRequest, "pageSize must not exceed $MAX_PAGE_SIZE")
+    }
+
+    return page to pageSize
+}
+
+private fun io.ktor.server.application.ApplicationCall.parsePositiveIntParam(
+    name: String,
+    default: Int,
+): Int {
+    val raw = request.queryParameters[name] ?: return default
+    val value = raw.toIntOrNull() ?: throw AbortError(HttpError.BadRequest, "$name must be an integer")
+    if (value < 1) throw AbortError(HttpError.BadRequest, "$name must be >= 1")
+    return value
 }
 
 private suspend fun io.ktor.server.application.ApplicationCall.receiveOpmlFile(): OpmlFile {

--- a/src/main/kotlin/io/pcast/module/feed/model/FeedRepository.kt
+++ b/src/main/kotlin/io/pcast/module/feed/model/FeedRepository.kt
@@ -102,6 +102,20 @@ class FeedRepository(
         }
     }
 
+    /**
+     * Deletes a feed identified by [nanoId] and owned by [ownerId]. Returns true if a row was
+     * deleted, false (caller should surface as 404) if the nanoId is not owned by this user.
+     */
+    fun deleteByNanoId(
+        nanoId: String,
+        ownerId: UUID,
+    ): Boolean =
+        transaction(db) {
+            FeedsTable.deleteWhere {
+                (FeedsTable.nanoId eq nanoId) and (FeedsTable.userId eq ownerId)
+            } > 0
+        }
+
     private fun mapRow(row: ResultRow) =
         Feed(
             id = row[FeedsTable.id].value,

--- a/src/main/kotlin/io/pcast/module/feed/model/FeedRepository.kt
+++ b/src/main/kotlin/io/pcast/module/feed/model/FeedRepository.kt
@@ -66,7 +66,35 @@ class FeedRepository(
             FeedsTable
                 .selectAll()
                 .where { FeedsTable.userId eq ownerId }
+                .orderBy(FeedsTable.id)
                 .map(::mapRow)
+        }
+
+    /**
+     * Returns a single page of feeds owned by [ownerId], ordered by id (UUIDv7, i.e. creation
+     * order) for stable pagination.
+     */
+    fun findPage(
+        ownerId: UUID,
+        limit: Int,
+        offset: Int,
+    ): List<Feed> =
+        transaction(db) {
+            FeedsTable
+                .selectAll()
+                .where { FeedsTable.userId eq ownerId }
+                .orderBy(FeedsTable.id)
+                .limit(limit)
+                .offset(offset.toLong())
+                .map(::mapRow)
+        }
+
+    fun count(ownerId: UUID): Long =
+        transaction(db) {
+            FeedsTable
+                .selectAll()
+                .where { FeedsTable.userId eq ownerId }
+                .count()
         }
 
     fun find(

--- a/src/main/kotlin/io/pcast/module/feed/opml/OmplFile.kt
+++ b/src/main/kotlin/io/pcast/module/feed/opml/OmplFile.kt
@@ -16,7 +16,40 @@ data class OpmlFile(
     val version: String,
     val head: OpmlHead,
     val body: OpmlBody,
-)
+) {
+    companion object {
+        private const val OPML_VERSION = "2.0"
+        private const val RSS_OUTLINE_TYPE = "rss"
+
+        /**
+         * Builds an OPML 2.0 document from a list of [feeds], nesting each feed as an `rss`
+         * outline under a single "feeds" parent outline (mirrors the import structure).
+         */
+        fun fromFeeds(
+            feeds: List<Feed>,
+            title: String = "pcast subscriptions",
+        ): OpmlFile =
+            OpmlFile(
+                version = OPML_VERSION,
+                head = OpmlHead(title = title),
+                body =
+                    OpmlBody(
+                        outlines =
+                            OpmlOutlines(
+                                text = "feeds",
+                                outlines =
+                                    feeds.map {
+                                        OpmlOutline(
+                                            text = it.title,
+                                            type = RSS_OUTLINE_TYPE,
+                                            xmlUrl = it.url,
+                                        )
+                                    },
+                            ),
+                    ),
+            )
+    }
+}
 
 @Serializable
 @XmlSerialName("head")

--- a/src/main/kotlin/io/pcast/plugins/RateLimit.kt
+++ b/src/main/kotlin/io/pcast/plugins/RateLimit.kt
@@ -15,6 +15,7 @@ import kotlin.time.Duration.Companion.minutes
  * in-memory store with a shared Redis-backed limiter.
  */
 val RATE_LIMIT_LOGIN = RateLimitName("login")
+val RATE_LIMIT_REGISTER = RateLimitName("register")
 val RATE_LIMIT_REFRESH = RateLimitName("refresh")
 val RATE_LIMIT_PASSKEY = RateLimitName("passkey")
 
@@ -24,6 +25,14 @@ fun Application.configureRateLimit() {
         // bcrypt at cost 12 provides ~200ms natural throttling per attempt,
         // but a distributed attack across many IPs still warrants a hard limit.
         register(RATE_LIMIT_LOGIN) {
+            rateLimiter(limit = 5, refillPeriod = 1.minutes)
+            requestKey { call ->
+                call.request.local.remoteAddress
+            }
+        }
+
+        // Registration: 5 accounts per minute per IP address to curb automated signup abuse.
+        register(RATE_LIMIT_REGISTER) {
             rateLimiter(limit = 5, refillPeriod = 1.minutes)
             requestKey { call ->
                 call.request.local.remoteAddress

--- a/src/main/kotlin/io/pcast/plugins/Validation.kt
+++ b/src/main/kotlin/io/pcast/plugins/Validation.kt
@@ -6,6 +6,7 @@ import io.ktor.server.plugins.requestvalidation.RequestValidation
 import io.ktor.server.plugins.requestvalidation.ValidationResult
 import io.pcast.module.auth.passkey.request.PasskeyAuthenticationOptionsRequest
 import io.pcast.module.auth.request.LoginRequest
+import io.pcast.module.auth.request.RegisterRequest
 import io.pcast.module.feed.request.FeedRequest
 import io.pcast.module.sync.request.ValidateSyncPhraseRequest
 
@@ -24,6 +25,13 @@ fun Application.configureValidation() {
             if (req.password.toByteArray().size > PASSWORD_MAX_BYTES) {
                 errors += "password: exceeds maximum of $PASSWORD_MAX_BYTES bytes"
             }
+            if (errors.isEmpty()) ValidationResult.Valid else ValidationResult.Invalid(errors.joinToString("; "))
+        }
+
+        validate<RegisterRequest> { req ->
+            val errors = mutableListOf<String>()
+            if (!EMAIL_REGEX.matches(req.email)) errors += "email: invalid format"
+            errors += validateNewPassword(req.password)
             if (errors.isEmpty()) ValidationResult.Valid else ValidationResult.Invalid(errors.joinToString("; "))
         }
 

--- a/src/test/kotlin/io/pcast/module/auth/api/AuthRouterTest.kt
+++ b/src/test/kotlin/io/pcast/module/auth/api/AuthRouterTest.kt
@@ -24,6 +24,7 @@ import io.pcast.module.auth.passkey.request.PasskeyAuthenticationOptionsRequest
 import io.pcast.module.auth.passkey.response.PasskeyCredentialResponse
 import io.pcast.module.auth.request.LoginRequest
 import io.pcast.module.auth.request.RefreshRequest
+import io.pcast.module.auth.request.RegisterRequest
 import io.pcast.module.auth.response.TokenResponse
 import io.pcast.module.testConfigModule
 import io.pcast.module.testDbModule
@@ -48,6 +49,94 @@ private const val TEST_PASSWORD = "testpassword123"
 
 internal class AuthRouterTest : KoinTest {
     private val authService by inject<AuthService>()
+
+    @Test
+    fun testRegisterSuccess() =
+        testApplication {
+            val client = configureServerAndGetClient()
+
+            client
+                .post("/api/auth/register") {
+                    header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                    setBody(RegisterRequest("newuser@example.com", "newpassword12345"))
+                }.expect {
+                    assertEquals(HttpStatusCode.Created, status)
+
+                    val response = body<TokenResponse>()
+
+                    assertNotNull(response.accessToken)
+                    assertNotNull(response.refreshToken)
+                    assertEquals("Bearer", response.tokenType)
+                    assertTrue(response.expiresIn > 0)
+                }
+        }
+
+    @Test
+    fun testRegisterDuplicateEmail() =
+        testApplication {
+            val client = configureServerAndGetClient()
+
+            // TEST_EMAIL is already seeded
+            client
+                .post("/api/auth/register") {
+                    header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                    setBody(RegisterRequest(TEST_EMAIL, "anotherpassword12345"))
+                }.expect {
+                    assertEquals(HttpStatusCode.Conflict, status)
+                }
+        }
+
+    @Test
+    fun testRegisterInvalidEmail() =
+        testApplication {
+            val client = configureServerAndGetClient()
+
+            client
+                .post("/api/auth/register") {
+                    header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                    setBody(RegisterRequest("not-an-email", "validpassword12345"))
+                }.expect {
+                    assertEquals(HttpStatusCode.BadRequest, status)
+                }
+        }
+
+    @Test
+    fun testRegisterShortPassword() =
+        testApplication {
+            val client = configureServerAndGetClient()
+
+            client
+                .post("/api/auth/register") {
+                    header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                    setBody(RegisterRequest("shortpw@example.com", "short"))
+                }.expect {
+                    assertEquals(HttpStatusCode.BadRequest, status)
+                }
+        }
+
+    @Test
+    fun testRegisteredUserCanLogin() =
+        testApplication {
+            val client = configureServerAndGetClient()
+            val email = "loginafterregister@example.com"
+            val password = "registerthenlogin12345"
+
+            client
+                .post("/api/auth/register") {
+                    header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                    setBody(RegisterRequest(email, password))
+                }.expect {
+                    assertEquals(HttpStatusCode.Created, status)
+                }
+
+            client
+                .post("/api/auth/login") {
+                    header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                    setBody(LoginRequest(email, password))
+                }.expect {
+                    assertEquals(HttpStatusCode.OK, status)
+                }
+        }
 
     @Test
     fun testLoginSuccess() =

--- a/src/test/kotlin/io/pcast/module/feed/api/FeedRouterTest.kt
+++ b/src/test/kotlin/io/pcast/module/feed/api/FeedRouterTest.kt
@@ -96,6 +96,100 @@ internal class FeedRouterTest : KoinTest {
         }
 
     @Test
+    fun testGetFeedsSetsTotalCountHeader() =
+        testApplication {
+            val ctx = configureServerAndGetContext()
+
+            ctx.client
+                .get("/api/feeds") {
+                    bearerAuth(ctx.accessToken)
+                }.expect {
+                    assertEquals(HttpStatusCode.OK, status)
+                    assertEquals("10", headers["X-Total-Count"])
+                }
+        }
+
+    @Test
+    fun testGetFeedsFirstPage() =
+        testApplication {
+            val ctx = configureServerAndGetContext()
+
+            ctx.client
+                .get("/api/feeds?page=1&pageSize=4") {
+                    bearerAuth(ctx.accessToken)
+                }.expect {
+                    assertEquals(HttpStatusCode.OK, status)
+                    assertEquals("10", headers["X-Total-Count"])
+                    assertEquals(4, body<List<FeedResponse>>().size)
+                }
+        }
+
+    @Test
+    fun testGetFeedsLastPagePartial() =
+        testApplication {
+            val ctx = configureServerAndGetContext()
+
+            ctx.client
+                .get("/api/feeds?page=3&pageSize=4") {
+                    bearerAuth(ctx.accessToken)
+                }.expect {
+                    assertEquals(HttpStatusCode.OK, status)
+                    assertEquals(2, body<List<FeedResponse>>().size)
+                }
+        }
+
+    @Test
+    fun testGetFeedsPagesDoNotOverlap() =
+        testApplication {
+            val ctx = configureServerAndGetContext()
+
+            val page1 =
+                ctx.client
+                    .get("/api/feeds?page=1&pageSize=4") { bearerAuth(ctx.accessToken) }
+                    .body<List<FeedResponse>>()
+                    .map { it.nanoId }
+            val page2 =
+                ctx.client
+                    .get("/api/feeds?page=2&pageSize=4") { bearerAuth(ctx.accessToken) }
+                    .body<List<FeedResponse>>()
+                    .map { it.nanoId }
+
+            assertEquals(emptyList(), page1.intersect(page2.toSet()).toList())
+        }
+
+    @Test
+    fun testGetFeedsEmptyReturnsOkWithEmptyArray() =
+        testApplication {
+            val ctx = configureServerAndGetContext()
+            // Second seeded user has no feeds
+            val secondUserToken = loginSecondUser(ctx.client)
+
+            ctx.client
+                .get("/api/feeds") {
+                    bearerAuth(secondUserToken)
+                }.expect {
+                    assertEquals(HttpStatusCode.OK, status)
+                    assertEquals("0", headers["X-Total-Count"])
+                    assertEquals(emptyList(), body<List<FeedResponse>>())
+                }
+        }
+
+    @Test
+    fun testGetFeedsRejectsInvalidPagination() =
+        testApplication {
+            val ctx = configureServerAndGetContext()
+
+            for (query in listOf("page=0", "pageSize=0", "page=abc", "pageSize=99999")) {
+                ctx.client
+                    .get("/api/feeds?$query") {
+                        bearerAuth(ctx.accessToken)
+                    }.expect {
+                        assertEquals(HttpStatusCode.BadRequest, status, "expected 400 for ?$query")
+                    }
+            }
+        }
+
+    @Test
     fun testGetFeed() =
         testApplication {
             val ctx = configureServerAndGetContext()

--- a/src/test/kotlin/io/pcast/module/feed/api/FeedRouterTest.kt
+++ b/src/test/kotlin/io/pcast/module/feed/api/FeedRouterTest.kt
@@ -11,6 +11,7 @@ import io.ktor.client.request.post
 import io.ktor.client.request.put
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
@@ -30,6 +31,7 @@ import io.pcast.module.auth.request.LoginRequest
 import io.pcast.module.auth.response.TokenResponse
 import io.pcast.module.feed.model.Feed
 import io.pcast.module.feed.model.FeedRepository
+import io.pcast.module.feed.opml.OpmlFile
 import io.pcast.module.feed.request.FeedRequest
 import io.pcast.module.feed.response.FeedResponse
 import io.pcast.module.testConfigModule
@@ -387,6 +389,77 @@ internal class FeedRouterTest : KoinTest {
 
             assertEquals("User 1 shared feed", feedRepository.findByNanoId(sharedNanoId, ctx.userId).title)
             assertEquals("User 2 shared feed", feedRepository.findByNanoId(sharedNanoId, secondUser.id).title)
+        }
+
+    @Test
+    fun testOpmlExportReturnsAllFeeds() =
+        testApplication {
+            val ctx = configureServerAndGetContext()
+            val feeds = feedRepository.findAll(ctx.userId)
+
+            ctx.client
+                .get("/api/feeds/opml") {
+                    bearerAuth(ctx.accessToken)
+                }.expect {
+                    assertEquals(HttpStatusCode.OK, status)
+
+                    val opml = body<OpmlFile>()
+                    assertEquals(feeds.size, opml.body.outlines.outlines.size)
+                    assertEquals(
+                        feeds.map { it.url }.toSet(),
+                        opml.body.outlines
+                            .map { it.xmlUrl }
+                            .toSet(),
+                    )
+                }
+        }
+
+    @Test
+    fun testOpmlExportScopedToUser() =
+        testApplication {
+            val ctx = configureServerAndGetContext()
+            // Second seeded user has no feeds
+            val secondUserToken = loginSecondUser(ctx.client)
+
+            ctx.client
+                .get("/api/feeds/opml") {
+                    bearerAuth(secondUserToken)
+                }.expect {
+                    assertEquals(HttpStatusCode.OK, status)
+                    assertEquals(
+                        0,
+                        body<OpmlFile>()
+                            .body.outlines.outlines.size,
+                    )
+                }
+        }
+
+    @Test
+    fun testOpmlRoundTrip() =
+        testApplication {
+            val ctx = configureServerAndGetContext()
+            val secondUserToken = loginSecondUser(ctx.client)
+
+            // Export user 1's feeds, then import them for user 2
+            val exported =
+                ctx.client
+                    .get("/api/feeds/opml") { bearerAuth(ctx.accessToken) }
+                    .bodyAsText()
+
+            ctx.client
+                .post("/api/feeds/opml") {
+                    bearerAuth(secondUserToken)
+                    header(HttpHeaders.ContentType, ContentType.Application.Xml.toString())
+                    setBody(exported)
+                }.expect {
+                    assertEquals(HttpStatusCode.Created, status)
+                }
+
+            val secondUser = authService.getUserByEmail(TEST_EMAIL_2)!!
+            assertEquals(
+                feedRepository.findAll(ctx.userId).map { it.url }.toSet(),
+                feedRepository.findAll(secondUser.id).map { it.url }.toSet(),
+            )
         }
 
     @Test

--- a/src/test/kotlin/io/pcast/module/feed/api/FeedRouterTest.kt
+++ b/src/test/kotlin/io/pcast/module/feed/api/FeedRouterTest.kt
@@ -4,6 +4,7 @@ import com.fasterxml.uuid.Generators
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.delete
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.post
@@ -225,6 +226,59 @@ internal class FeedRouterTest : KoinTest {
                 }.expect {
                     assertEquals(HttpStatusCode.NotFound, status)
                 }
+        }
+
+    @Test
+    fun testDeleteFeed() =
+        testApplication {
+            val ctx = configureServerAndGetContext()
+            val feed = feedRepository.findAll(ctx.userId).first()
+
+            ctx.client
+                .delete("/api/feeds/${feed.nanoId}") {
+                    bearerAuth(ctx.accessToken)
+                }.expect {
+                    assertEquals(HttpStatusCode.NoContent, status)
+                }
+
+            ctx.client
+                .get("/api/feeds/${feed.nanoId}") {
+                    bearerAuth(ctx.accessToken)
+                }.expect {
+                    assertEquals(HttpStatusCode.NotFound, status)
+                }
+        }
+
+    @Test
+    fun testDeleteFeedFailsWithUnknownId() =
+        testApplication {
+            val ctx = configureServerAndGetContext()
+
+            ctx.client
+                .delete("/api/feeds/does-not-exist") {
+                    bearerAuth(ctx.accessToken)
+                }.expect {
+                    assertEquals(HttpStatusCode.NotFound, status)
+                }
+        }
+
+    @Test
+    fun testUserCannotDeleteOtherUsersFeed() =
+        testApplication {
+            val ctx1 = configureServerAndGetContext()
+            val ctx2 = loginSecondUser(ctx1.client)
+
+            val feed = feedRepository.findAll(ctx1.userId).first()
+
+            ctx1.client
+                .delete("/api/feeds/${feed.nanoId}") {
+                    bearerAuth(ctx2)
+                }.expect {
+                    assertEquals(HttpStatusCode.NotFound, status)
+                }
+
+            // ctx1's feed must still exist
+            assertEquals(feed.title, feedRepository.findByNanoId(feed.nanoId, ctx1.userId).title)
         }
 
     @Test


### PR DESCRIPTION
Implements all four **Phase 0** features from `docs/roadmap.md` — small, self-contained changes that unblock basic real-world client usage. One commit per feature, each developed test-first.

## Features

| Endpoint | Description |
|---|---|
| `DELETE /feeds/{id}` | Unsubscribe from a feed. Owner-scoped by nanoId; cross-user or unknown id → 404 (same semantics as update). |
| `POST /auth/register` | Account signup. Wires up the previously-unreachable `createUser`. Auto-login (201 + access/refresh tokens), rate-limited. Email/password validated → 400; duplicate email → 409. |
| `GET /feeds` pagination | 1-based `page`/`pageSize` (defaults 1/50, max page size 100). Total exposed via `X-Total-Count` header so the response stays a bare array. Invalid/out-of-range → 400. Empty result now returns `200 []` instead of `204`. |
| `GET /feeds/opml` | Export subscriptions as an OPML 2.0 document, mirroring the existing import. Output round-trips back through `POST /feeds/opml`. |

## API contract decisions

- **Signup** returns tokens (auto-login) rather than a bare 201, so clients onboard in a single request.
- **Pagination** keeps the top-level JSON array and reports the total via `X-Total-Count` (no breaking change to the response shape); params are `page`/`pageSize`.

## Notes

- Pagination orders by `id` (UUIDv7 = creation order), since `feeds` has no `created_at`. Stable, but not user-configurable sorting — that's a Phase 4 concern.
- Register uses a read-then-insert duplicate check; the `users.email` unique index remains the authoritative guard, so a rare concurrent double-signup would surface as 500 rather than 409.
- Added `HttpError.Conflict` (409) and a `RATE_LIMIT_REGISTER` limiter (5/min/IP).

## Testing

Added 17 tests (3 delete, 5 register, 6 pagination, 3 OPML export), each written first and watched fail before implementing. Full `./gradlew build` (all tests + spotless) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)